### PR TITLE
Refactor of CSS for Table of Contents

### DIFF
--- a/css/new_a.css
+++ b/css/new_a.css
@@ -14,6 +14,28 @@
   padding: 0px;
 }
 
+#toc ul li ul li:last-child a {
+  border-bottom: none;
+}
+
+#toc ul li ul li a:hover {
+    border-top: 1px solid #000000;
+    margin-top: -1px;
+}
+
+#toc ul li ul li:last-child a:hover {
+  border-top: 1px solid #000000;
+  margin-top: -1px;
+}
+
+#toc ul li ul li:last-child {
+  margin-bottom: -0.3em;
+}
+
+#toc ul li ul li a {
+  border-top: none;
+}
+
 #toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
     font-weight: bold;
     color: #ffffff;

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -11,6 +11,17 @@ xxxxxxxxx.mathbook-content tt.code-inline {
     padding-left: 0.2em;
 }
 
+#toc ul li.active a, #toc ul li.active a:link, #toc ul li.active a:visited {
+    font-weight: bold;
+    background: #932919
+}
+/*The javascript is causing the color to change.*/
+
+#toc ul li a:hover {
+    background: #671d12;
+    border-color: #3c110a;
+}
+
 #toc > ul > li:not(:first-child) {
     margin-top: 0.3em;
 }

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -2,3 +2,18 @@
 xxxxxxxxx.mathbook-content tt.code-inline {
     font-size: 200%;
 }
+
+#toc > ul  a  {
+    font-weight: bold;
+}
+
+
+#toc ul li a, #toc ul li a:link, #toc ul li a:visited {
+    color: #ffffff;
+    background: #3572a0;
+  }
+
+#toc ul li ul li a, #toc ul li a ul li a:link, #toc ul li ul li a:visited {
+    color: #671d12;
+    background: #f0f0f0;
+  }

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -1,12 +1,17 @@
 #toc {
   /* IMPORTANT height must be calculated by javascript. */
-  width: 240px;
-  margin: 0;
-  font-size: 14.72px;
-  overflow-y: auto;
-  overflow-x: hidden;
-  /* Enable momentum scrolling on iOS */
-  -webkit-overflow-scrolling: touch;
+    width: 240px;
+    margin: 0;
+    font-size: 14.72px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    /* Enable momentum scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+}
+
+#toc ul {
+  margin: 0px;
+  padding: 0px;
 }
 
 #toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
@@ -46,17 +51,3 @@
 #toc > ul > li > a .codenumber + .title {
     margin-left: 2em;
 }
-
-/*#toc ul li:first-child {
-   margin-top: 0;
-}
-
-#toc ul li a, #toc ul li a:link, #toc ul li a:visited {
-    color: #ffffff;
-    background: #3572a0;
-  }
-
-#toc ul li ul li a, #toc ul li a ul li a:link, #toc ul li ul li a:visited {
-    color: #671d12;
-    background: #f0f0f0;
-  }*/

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -1,6 +1,12 @@
-
-xxxxxxxxx.mathbook-content tt.code-inline {
-    font-size: 200%;
+#toc {
+  /* IMPORTANT height must be calculated by javascript. */
+  width: 240px;
+  margin: 0;
+  font-size: 14.72px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  /* Enable momentum scrolling on iOS */
+  -webkit-overflow-scrolling: touch;
 }
 
 #toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
@@ -15,7 +21,6 @@ xxxxxxxxx.mathbook-content tt.code-inline {
 #toc ul li a.active {
     background: #932919
 }
-/*The javascript is causing the color to change.*/
 
 #toc ul li a:hover {
     background: #671d12;

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -49,37 +49,11 @@
     text-decoration: none;
 }
 
-/* Begin defining colors: */
-
-/* Sets subsection color scheme */
-#toc ul li a, #toc ul li a:link, #toc ul li a:visited {
-    color: #671d12;
-    background: #f0f0f0;
-}
-
-/* Sets section-header color scheme. Also styles/places them correctly. */
 #toc > ul > li > a, #toc > ul > li > a:link, #toc > ul > li > a:visited {
     font-weight: bold;
-    color: #ffffff;
-    background: #3572a0;
-    border-color: #30668e;
     font-family: "PT Serif", "Times New Roman", Times, serif;
     padding-left: 0.2em;
 }
-
-/* Sets colors of the active section. Also sets its depressed state. */
-#toc ul li a.active {
-    background: #932919
-}
-
-/* Sets colors while hovering */
-#toc ul li a:hover {
-    color: #ffffff;
-    background: #671d12;
-    border-color: #3c110a;
-}
-
-/* End defining colors */
 
 /* Ensures that there is no double border between subsections */
 #toc ul li ul a {
@@ -106,3 +80,33 @@ the margin on top of sections being used to space out adjacent sections) */
 #toc ul li a:active {
   box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }
+
+/* Begin defining colors: */
+
+/* Sets subsection color scheme */
+#toc ul li a, #toc ul li a:link, #toc ul li a:visited {
+    color: #671d12;
+    background: #f0f0f0;
+}
+
+/* Sets section-header color scheme. */
+#toc > ul > li > a, #toc > ul > li > a:link, #toc > ul > li > a:visited {
+    color: #ffffff;
+    background: #3572a0;
+    border-color: #30668e;
+}
+
+/* Sets colors of the active section. */
+#toc ul li a.active {
+    background: #932919;
+    color: #ffffff;
+}
+
+/* Sets colors while hovering */
+#toc ul li a:hover {
+    color: #ffffff;
+    background: #671d12;
+    border-color: #3c110a;
+}
+
+/* End defining colors */

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -3,10 +3,37 @@ xxxxxxxxx.mathbook-content tt.code-inline {
     font-size: 200%;
 }
 
-#toc > ul  a  {
+#toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
     font-weight: bold;
+    color: #ffffff;
+    background: #3572a0;
+    font-family: "PT Serif", "Times New Roman", Times, serif;
+    padding-left: 0.2em;
 }
 
+#toc > ul > li:not(:first-child) {
+    margin-top: 0.3em;
+}
+
+#toc > ul > li:first-child .title {
+    margin-left: 2em;
+}
+
+#toc > ul > li > a .codenumber {
+    position: absolute;
+    margin-right: 0;
+    margin-left: 0.5em;
+    left: 0.3em;
+    display: inline-block;
+}
+
+#toc > ul > li > a .codenumber + .title {
+    margin-left: 2em;
+}
+
+/*#toc ul li:first-child {
+   margin-top: 0;
+}
 
 #toc ul li a, #toc ul li a:link, #toc ul li a:visited {
     color: #ffffff;
@@ -16,4 +43,4 @@ xxxxxxxxx.mathbook-content tt.code-inline {
 #toc ul li ul li a, #toc ul li a ul li a:link, #toc ul li ul li a:visited {
     color: #671d12;
     background: #f0f0f0;
-  }
+  }*/

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -18,7 +18,7 @@
     position: relative;
     display: block;
     padding: 2.86957px;
-    padding-left: 25.872px;
+    padding-left: 1.5em;
     border-top: 1px solid #d1d1d1;
     border-bottom: 1px solid #d1d1d1;
 }
@@ -39,16 +39,6 @@
     color: white;
     background: #671d12;
     border-color: #3c110a;
-}
-
-#toc .codenumber + .title {
-    display: inline-block;
-    /*Not sure if the rest of this is important or not*/
-    vertical-align: baseline;
-    *vertical-align: auto;
-    zoom: 1;
-    *display: inline;
-    margin-left: 16.192px;
 }
 
 #toc ul li ul li:last-child a {
@@ -97,11 +87,12 @@
 #toc > ul > li > a .codenumber {
     position: absolute;
     margin-right: 0;
-    margin-left: 0.5em;
+    margin-left: 0em;
     left: 0.3em;
     display: inline-block;
 }
 
 #toc > ul > li > a .codenumber + .title {
-    margin-left: 2em;
+    margin-left: 1.3em;
+    display: inline-block;
 }

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -10,30 +10,57 @@
 }
 
 #toc ul {
-  margin: 0px;
-  padding: 0px;
+    margin: 0px;
+    padding: 0px;
+}
+
+#toc ul li a {
+    position: relative;
+    display: block;
+    padding: 2.86957px;
+    padding-left: 25.872px;
+    border-top: 1px solid #d1d1d1;
+    border-bottom: 1px solid #d1d1d1;
+}
+
+/*Removes underlines from links in toc*/
+#toc ul li a, #toc ul li a:link, #toc ul li a:visited, #toc ul li a:hover, #toc ul li a:active {
+    text-decoration: none;
+}
+
+/*Sets subsection color scheme*/
+#toc ul li a, #toc ul li a:link, #toc ul li a:visited {
+    color: #671d12;
+    background: #f0f0f0;
+}
+
+/*Sets colors while hovering*/
+#toc ul li a:hover {
+    color: white;
+    background: #671d12;
+    border-color: #3c110a;
+}
+
+#toc .codenumber + .title {
+    display: inline-block;
+    /*Not sure if the rest of this is important or not*/
+    vertical-align: baseline;
+    *vertical-align: auto;
+    zoom: 1;
+    *display: inline;
+    margin-left: 16.192px;
 }
 
 #toc ul li ul li:last-child a {
-  border-bottom: none;
-}
-
-#toc ul li ul li a:hover {
-    border-top: 1px solid #000000;
-    margin-top: -1px;
-}
-
-#toc ul li ul li:last-child a:hover {
-  border-top: 1px solid #000000;
-  margin-top: -1px;
+    border-bottom: none;
 }
 
 #toc ul li ul li:last-child {
-  margin-bottom: -0.3em;
+    margin-bottom: -0.3em;
 }
 
 #toc ul li ul li a {
-  border-top: none;
+    border-top: none;
 }
 
 #toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
@@ -54,11 +81,16 @@
     border-color: #3c110a;
 }
 
+#toc ul li ul a:hover {
+    border-top: 1px solid #3c110a;
+    margin-top: -1px;
+}
+
 #toc > ul > li:not(:first-child) {
     margin-top: 0.3em;
 }
 
-#toc > ul > li:first-child .title {
+#toc > ul > li:first-child .title, #toc > ul > li:last-child .title {
     margin-left: 2em;
 }
 

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -5,55 +5,60 @@
     font-size: 14.72px;
     overflow-y: auto;
     overflow-x: hidden;
-    /* Enable momentum scrolling on iOS */
-    -webkit-overflow-scrolling: touch;
 }
 
+/* Aligns toc to the top and side of the allotted space, respectively */
 #toc ul {
     margin: 0px;
     padding: 0px;
+}
+
+/* Places section titles */
+#toc .title {
+    margin-left: 1.4em;
+    display: inline-block;
+}
+
+
+/* Places codenumbers */
+#toc .codenumber {
+    position: absolute;
+    margin-right: 0;
+    margin-left: 0em;
+    margin-top: 0.4px;
+    left: 0.3em;
+    display: inline-block;
 }
 
 #toc ul li a {
     position: relative;
     display: block;
     padding: 2.86957px;
-    padding-left: 1.5em;
+    padding-left: 1.6em;
     border-top: 1px solid #d1d1d1;
     border-bottom: 1px solid #d1d1d1;
 }
 
-/*Removes underlines from links in toc*/
+/* Sets spacing between section headings*/
+#toc > ul > li:not(:first-child) {
+    margin-top: 0.3em;
+}
+
+/* Removes underlines from links in toc */
 #toc ul li a, #toc ul li a:link, #toc ul li a:visited, #toc ul li a:hover, #toc ul li a:active {
     text-decoration: none;
 }
 
-/*Sets subsection color scheme*/
+/* Begin defining colors: */
+
+/* Sets subsection color scheme */
 #toc ul li a, #toc ul li a:link, #toc ul li a:visited {
     color: #671d12;
     background: #f0f0f0;
 }
 
-/*Sets colors while hovering*/
-#toc ul li a:hover {
-    color: white;
-    background: #671d12;
-    border-color: #3c110a;
-}
-
-#toc ul li ul li:last-child a {
-    border-bottom: none;
-}
-
-#toc ul li ul li:last-child {
-    margin-bottom: -0.3em;
-}
-
-#toc ul li ul li a {
-    border-top: none;
-}
-
-#toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
+/* Sets section-header color scheme. Also styles/places them correctly. */
+#toc > ul > li > a, #toc > ul > li > a:link, #toc > ul > li > a:visited {
     font-weight: bold;
     color: #ffffff;
     background: #3572a0;
@@ -62,37 +67,42 @@
     padding-left: 0.2em;
 }
 
+/* Sets colors of the active section. Also sets its depressed state. */
 #toc ul li a.active {
     background: #932919
 }
 
+/* Sets colors while hovering */
 #toc ul li a:hover {
+    color: #ffffff;
     background: #671d12;
     border-color: #3c110a;
 }
 
+/* End defining colors */
+
+/* Ensures that there is no double border between subsections */
+#toc ul li ul a {
+    border-top: none;
+}
+
+/* Allows both "top" and bottom border of a subsection to be highlighted on hover */
 #toc ul li ul a:hover {
     border-top: 1px solid #3c110a;
     margin-top: -1px;
 }
 
-#toc > ul > li:not(:first-child) {
-    margin-top: 0.3em;
+/* Removes the excess space between the last subsection and the next section (caused by
+the margin on top of sections being used to space out adjacent sections) */
+#toc ul li ul li:last-child {
+    margin-bottom: -0.3em;
 }
 
-#toc > ul > li:first-child .title, #toc > ul > li:last-child .title {
-    margin-left: 2em;
+/* Removes double border between last subsection and next section */
+#toc ul li ul li:last-child a {
+    border-bottom: none;
 }
 
-#toc > ul > li > a .codenumber {
-    position: absolute;
-    margin-right: 0;
-    margin-left: 0em;
-    left: 0.3em;
-    display: inline-block;
-}
-
-#toc > ul > li > a .codenumber + .title {
-    margin-left: 1.3em;
-    display: inline-block;
+#toc ul li a:active {
+  box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }

--- a/css/new_a.css
+++ b/css/new_a.css
@@ -7,12 +7,12 @@ xxxxxxxxx.mathbook-content tt.code-inline {
     font-weight: bold;
     color: #ffffff;
     background: #3572a0;
+    border-color: #30668e;
     font-family: "PT Serif", "Times New Roman", Times, serif;
     padding-left: 0.2em;
 }
 
-#toc ul li.active a, #toc ul li.active a:link, #toc ul li.active a:visited {
-    font-weight: bold;
+#toc ul li a.active {
     background: #932919
 }
 /*The javascript is causing the color to change.*/

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -1,19 +1,23 @@
-/*#toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
+#toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
     font-weight: bold;
-    color: #707070;
-    background: #c1dff5;
+    color: #505050;
+    background: #dbf5ff;
+    border-color: #afc2e5;
     font-family: "PT Serif", "Times New Roman", Times, serif;
     padding-left: 0.2em;
 }
 
-#toc ul li a:active:active, #toc ul li a:active.active {
-    background: #ffb1a5;
+#toc ul li a.active {
+    color: #404040;
+    background: #fae5b6;
+    border-color: #d7b772;
 }
+/*The javascript is causing the color to change.*/
 
 #toc ul li a:hover {
-    color: #000000;
-    background: #ff8472;
-    border-color: #f46149;
+    color: #321a0c;
+    background: #fac793;
+    border-color: #ec704b;
 }
 
 #toc > ul > li:not(:first-child) {
@@ -34,4 +38,4 @@
 
 #toc > ul > li > a .codenumber + .title {
     margin-left: 2em;
-}*/
+}

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -1,0 +1,37 @@
+/*#toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
+    font-weight: bold;
+    color: #707070;
+    background: #c1dff5;
+    font-family: "PT Serif", "Times New Roman", Times, serif;
+    padding-left: 0.2em;
+}
+
+#toc ul li a:active:active, #toc ul li a:active.active {
+    background: #ffb1a5;
+}
+
+#toc ul li a:hover {
+    color: #000000;
+    background: #ff8472;
+    border-color: #f46149;
+}
+
+#toc > ul > li:not(:first-child) {
+    margin-top: 0.3em;
+}
+
+#toc > ul > li:first-child .title {
+    margin-left: 2em;
+}
+
+#toc > ul > li > a .codenumber {
+    position: absolute;
+    margin-right: 0;
+    margin-left: 0.5em;
+    left: 0.3em;
+    display: inline-block;
+}
+
+#toc > ul > li > a .codenumber + .title {
+    margin-left: 2em;
+}*/

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -7,17 +7,21 @@
     padding-left: 0.2em;
 }
 
-#toc ul li a.active {
-    color: #404040;
-    background: #fae5b6;
-    border-color: #d7b772;
+#toc ul li ul a, #toc ul li ul a:link, #toc ul li ul a:visited {
+    color: #505050;
+    background: #ffffff;
 }
-/*The javascript is causing the color to change.*/
 
-#toc ul li a:hover {
+#toc ul li a:hover, #toc ul li ul a:hover {
     color: #321a0c;
     background: #fac793;
     border-color: #ec704b;
+}
+
+#toc ul li a.active, ul li ul a.active {
+    color: #404040;
+    background: #fae5b6;
+    border-color: #d7b772;
 }
 
 #toc > ul > li:not(:first-child) {

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -5,7 +5,7 @@
 }
 
 #toc ul li ul a, #toc ul li ul a:link, #toc ul li ul a:visited {
-    color: #505050;
+    color: #404040;
     background: #ffffff;
 }
 

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -1,3 +1,19 @@
+#toc {
+  /* IMPORTANT height must be calculated by javascript. */
+    width: 240px;
+    margin: 0;
+    font-size: 14.72px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    /* Enable momentum scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+}
+
+#toc ul {
+  margin: 0px;
+  padding: 0px;
+}
+
 #toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
     font-weight: bold;
     color: #505050;

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -1,4 +1,4 @@
-#toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
+/*#toc > ul > li > a, #toc > ul > li > a:link, #toc > ul > li > a:visited {
     color: #505050;
     background: #dbf5ff;
     border-color: #afc2e5;
@@ -15,8 +15,8 @@
     border-color: #ec704b;
 }
 
-#toc ul li a.active, ul li ul a.active {
+#toc ul li a.active, #toc ul li ul a.active {
     color: #404040;
     background: #fae5b6;
     border-color: #d7b772;
-}
+}*/

--- a/css/new_b.css
+++ b/css/new_b.css
@@ -1,26 +1,7 @@
-#toc {
-  /* IMPORTANT height must be calculated by javascript. */
-    width: 240px;
-    margin: 0;
-    font-size: 14.72px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    /* Enable momentum scrolling on iOS */
-    -webkit-overflow-scrolling: touch;
-}
-
-#toc ul {
-  margin: 0px;
-  padding: 0px;
-}
-
 #toc > ul > li> a, #toc > ul > li> a:link, #toc > ul > li> a:visited {
-    font-weight: bold;
     color: #505050;
     background: #dbf5ff;
     border-color: #afc2e5;
-    font-family: "PT Serif", "Times New Roman", Times, serif;
-    padding-left: 0.2em;
 }
 
 #toc ul li ul a, #toc ul li ul a:link, #toc ul li ul a:visited {
@@ -38,24 +19,4 @@
     color: #404040;
     background: #fae5b6;
     border-color: #d7b772;
-}
-
-#toc > ul > li:not(:first-child) {
-    margin-top: 0.3em;
-}
-
-#toc > ul > li:first-child .title {
-    margin-left: 2em;
-}
-
-#toc > ul > li > a .codenumber {
-    position: absolute;
-    margin-right: 0;
-    margin-left: 0.5em;
-    left: 0.3em;
-    display: inline-block;
-}
-
-#toc > ul > li > a .codenumber + .title {
-    margin-left: 2em;
 }

--- a/css/refactor-3.css
+++ b/css/refactor-3.css
@@ -1581,18 +1581,18 @@ body.centered-container {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #toc ul li a:active:active, #toc ul li a:active.active {
+  #tocx ul li a:active:active, #toc ul li a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   }
 }
 /* line 151, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a {
+#tocx ul li a {
   border-top: none;
 }
 /* line 155, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a:hover {
+#tocx ul li a:hover {
   /* Cover the previous items border-bottom with our top */
   margin-top: -1px;
   border-top: 1px solid #3c110a;

--- a/css/refactor-3.css
+++ b/css/refactor-3.css
@@ -1358,7 +1358,7 @@ body.centered-container {
 
 /* The table-of-contents itself */
 /* line 107, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_layout.scss */
-#toc {
+#tocx {
   /*@import "../ui-config";*/
 }
 /* line 30, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
@@ -1484,7 +1484,7 @@ body.centered-container {
 }
 @media screen and (max-width: 800px) {
   /* line 105, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-  #toc .codenumber {
+  #tocx .codenumber {
     position: absolute;
     right: 100%;
     margin-right: -23.876px;
@@ -1539,14 +1539,14 @@ body.centered-container {
   /* Depressed state on click but not when marked active */
 }
 /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-#tox ul li a:active:active, #tox ul li a:active.active {
+#tocx ul li a:active:active, #tocx ul li a:active.active {
   -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }
 @media screen and (max-width: 800px) {
   /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a {
+  #tocx ul li a {
     position: relative;
     display: block;
     font-size: 14.72px;
@@ -1557,31 +1557,31 @@ body.centered-container {
     border-left: none;
   }
   /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a, #toc ul li a:link, #toc ul li a:visited, #toc ul li a:hover, #toc ul li a:active {
+  #tocx ul li a, #tocx ul li a:link, #tocx ul li a:visited, #tocx ul li a:hover, #tocx ul li a:active {
     text-decoration: none;
   }
   /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a, #toc ul li a:link, #toc ul li a:visited {
+  #tocx ul li a, #tocx ul li a:link, #tocx ul li a:visited {
     color: #671d12;
     background: #f0f0f0;
   }
   /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a.active, #toc ul li a:active {
+  #tocx ul li a.active, #tocx ul li a:active {
     color: white;
     background: #932919;
   }
   /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a:hover {
+  #tocx ul li a:hover {
     color: white;
     background: #671d12;
     border-color: #3c110a;
   }
   /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a:active {
+  #tocx ul li a:active {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #toc ul li a:active:active, #toc ul li a:active.active {
+  #tocx ul li a:active:active, #tocx ul li a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;

--- a/css/refactor-3.css
+++ b/css/refactor-3.css
@@ -1362,7 +1362,7 @@ body.centered-container {
   /*@import "../ui-config";*/
 }
 /* line 30, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#toc {
+#tocx {
   /* IMPORTANT height must be calculated by javascript. */
   width: 240px;
   margin: 0;
@@ -1373,7 +1373,7 @@ body.centered-container {
   -webkit-overflow-scrolling: touch;
 }
 /* line 46, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#toc h2 {
+#tocx h2 {
   display: block;
   font-family: "PT Serif", "Times New Roman", Times, serif;
   font-weight: 700;
@@ -1382,7 +1382,7 @@ body.centered-container {
   margin: 0;
 }
 /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc h2 a {
+#tocx h2 a {
   position: relative;
   display: block;
   font-size: 14.72px;
@@ -1393,38 +1393,38 @@ body.centered-container {
   border-left: none;
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc h2 a, #toc h2 a:link, #toc h2 a:visited, #toc h2 a:hover, #toc h2 a:active {
+#tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited, #tocx h2 a:hover, #tocx h2 a:active {
   text-decoration: none;
 }
 /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc h2 a, #toc h2 a:link, #toc h2 a:visited {
+#tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited {
   color: white;
   background: #3572a0;
 }
 /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc h2 a.active, #toc h2 a:active {
+#tocx h2 a.active, #tocx h2 a:active {
   color: white;
   background: #932919;
 }
 /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc h2 a:hover {
+#tocx h2 a:hover {
   color: white;
   background: #671d12;
   border-color: #3c110a;
 }
 /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc h2 a:active {
+#tocx h2 a:active {
   /* Depressed state on click but not when marked active */
 }
 /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-#toc h2 a:active:active, #toc h2 a:active.active {
+#tocx h2 a:active:active, #tocx h2 a:active.active {
   -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }
 @media screen and (max-width: 800px) {
   /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc h2 a {
+  #tocx h2 a {
     position: relative;
     display: block;
     font-size: 14.72px;
@@ -1435,31 +1435,31 @@ body.centered-container {
     border-left: none;
   }
   /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc h2 a, #toc h2 a:link, #toc h2 a:visited, #toc h2 a:hover, #toc h2 a:active {
+  #tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited, #tocx h2 a:hover, #tocx h2 a:active {
     text-decoration: none;
   }
   /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc h2 a, #toc h2 a:link, #toc h2 a:visited {
+  #tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited {
     color: white;
     background: #3572a0;
   }
   /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc h2 a.active, #toc h2 a:active {
+  #tocx h2 a.active, #tocx h2 a:active {
     color: white;
     background: #932919;
   }
   /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc h2 a:hover {
+  #tocx h2 a:hover {
     color: white;
     background: #671d12;
     border-color: #3c110a;
   }
   /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc h2 a:active {
+  #tocx h2 a:active {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #toc h2 a:active:active, #toc h2 a:active.active {
+  #tocx h2 a:active:active, #tocx h2 a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
@@ -1476,7 +1476,7 @@ body.centered-container {
   margin-left: 16.192px;
 }
 /* line 105, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#toc .codenumber {
+#tox .codenumber {
   position: absolute;
   right: 100%;
   margin-right: -21.456px;
@@ -1484,7 +1484,7 @@ body.centered-container {
 }
 @media screen and (max-width: 800px) {
   /* line 105, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-  #toc .codenumber {
+  #tox .codenumber {
     position: absolute;
     right: 100%;
     margin-right: -23.876px;
@@ -1492,7 +1492,7 @@ body.centered-container {
   }
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#toc ul {
+#tocx ul {
   margin: 0px;
   padding: 0px;
   list-style-type: none;
@@ -1598,11 +1598,11 @@ body.centered-container {
   border-top: 1px solid #3c110a;
 }
 /* line 180, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li:last-child a {
+#tocx ul li:last-child a {
   border-bottom-color: transparent;
 }
 /* line 184, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li:last-child a:hover {
+#tocx ul li:last-child a:hover {
   /* When we hover we want to show the last border */
   border-color: #3c110a;
 }

--- a/css/refactor-3.css
+++ b/css/refactor-3.css
@@ -1358,11 +1358,11 @@ body.centered-container {
 
 /* The table-of-contents itself */
 /* line 107, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_layout.scss */
-#toc {
+#tof {
   /*@import "../ui-config";*/
 }
 /* line 30, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tocx {
+#tofx {
   /* IMPORTANT height must be calculated by javascript. */
   width: 240px;
   margin: 0;
@@ -1373,7 +1373,7 @@ body.centered-container {
   -webkit-overflow-scrolling: touch;
 }
 /* line 46, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tocx h2 {
+#tofx h2 {
   display: block;
   font-family: "PT Serif", "Times New Roman", Times, serif;
   font-weight: 700;
@@ -1382,7 +1382,7 @@ body.centered-container {
   margin: 0;
 }
 /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx h2 a {
+#tofx h2 a {
   position: relative;
   display: block;
   font-size: 14.72px;
@@ -1393,38 +1393,38 @@ body.centered-container {
   border-left: none;
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited, #tocx h2 a:hover, #tocx h2 a:active {
+#tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited, #tofx h2 a:hover, #tofx h2 a:active {
   text-decoration: none;
 }
 /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited {
+#tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited {
   color: white;
   background: #3572a0;
 }
 /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx h2 a.active, #tocx h2 a:active {
+#tofx h2 a.active, #tofx h2 a:active {
   color: white;
   background: #932919;
 }
 /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx h2 a:hover {
+#tofx h2 a:hover {
   color: white;
   background: #671d12;
   border-color: #3c110a;
 }
 /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx h2 a:active {
+#tofx h2 a:active {
   /* Depressed state on click but not when marked active */
 }
 /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-#tocx h2 a:active:active, #tocx h2 a:active.active {
+#tofx h2 a:active:active, #tofx h2 a:active.active {
   -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }
 @media screen and (max-width: 800px) {
   /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tocx h2 a {
+  #tofx h2 a {
     position: relative;
     display: block;
     font-size: 14.72px;
@@ -1435,38 +1435,38 @@ body.centered-container {
     border-left: none;
   }
   /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited, #tocx h2 a:hover, #tocx h2 a:active {
+  #tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited, #tofx h2 a:hover, #tofx h2 a:active {
     text-decoration: none;
   }
   /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited {
+  #tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited {
     color: white;
     background: #3572a0;
   }
   /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tocx h2 a.active, #tocx h2 a:active {
+  #tofx h2 a.active, #tofx h2 a:active {
     color: white;
     background: #932919;
   }
   /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tocx h2 a:hover {
+  #tofx h2 a:hover {
     color: white;
     background: #671d12;
     border-color: #3c110a;
   }
   /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tocx h2 a:active {
+  #tofx h2 a:active {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #tocx h2 a:active:active, #tocx h2 a:active.active {
+  #tofx h2 a:active:active, #tofx h2 a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   }
 }
 /* line 101, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#toc .codenumber + .title {
+#tofx .codenumber + .title {
   display: -moz-inline-stack;
   display: inline-block;
   vertical-align: baseline;
@@ -1484,7 +1484,7 @@ body.centered-container {
 }
 @media screen and (max-width: 800px) {
   /* line 105, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-  #tox .codenumber {
+  #tof .codenumber {
     position: absolute;
     right: 100%;
     margin-right: -23.876px;
@@ -1492,61 +1492,61 @@ body.centered-container {
   }
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tocx ul {
+#tofx ul {
   margin: 0px;
   padding: 0px;
   list-style-type: none;
 }
 /* line 118, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#toc ul li {
+#tofx ul li {
   display: block;
   margin: 0px;
   padding: 0px;
 }
 /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a {
+#tofx ul li a {
   position: relative;
   display: block;
   font-size: 14.72px;
   padding: 2.86957px;
   padding-left: 25.872px;
   border: 1px solid #d1d1d1;
-  border-right: none;
   border-left: none;
+  border-right: none;
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a, #toc ul li a:link, #toc ul li a:visited, #toc ul li a:hover, #toc ul li a:active {
+#tofx ul li a, #tofx ul li a:link, #tofx ul li a:visited, #tofx ul li a:hover, #tofx ul li a:active {
   text-decoration: none;
 }
 /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a, #toc ul li a:link, #toc ul li a:visited {
+#tofx ul li a, #tofx ul li a:link, #tofx ul li a:visited {
   color: #671d12;
   background: #f0f0f0;
 }
 /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a.active, #toc ul li a:active {
+#tofx ul li a.active, #tofx ul li a:active {
   color: white;
   background: #932919;
 }
 /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a:hover {
+#tofx ul li a:hover {
   color: white;
   background: #671d12;
   border-color: #3c110a;
 }
 /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#toc ul li a:active {
+#tofx ul li a:active {
   /* Depressed state on click but not when marked active */
 }
 /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-#toc ul li a:active:active, #toc ul li a:active.active {
+#tox ul li a:active:active, #tox ul li a:active.active {
   -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }
 @media screen and (max-width: 800px) {
   /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a {
+  #tof ul li a {
     position: relative;
     display: block;
     font-size: 14.72px;
@@ -1557,52 +1557,52 @@ body.centered-container {
     border-left: none;
   }
   /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a, #toc ul li a:link, #toc ul li a:visited, #toc ul li a:hover, #toc ul li a:active {
+  #tof ul li a, #tof ul li a:link, #tof ul li a:visited, #tof ul li a:hover, #tof ul li a:active {
     text-decoration: none;
   }
   /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a, #toc ul li a:link, #toc ul li a:visited {
+  #tof ul li a, #tof ul li a:link, #tof ul li a:visited {
     color: #671d12;
     background: #f0f0f0;
   }
   /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a.active, #toc ul li a:active {
+  #tof ul li a.active, #tof ul li a:active {
     color: white;
     background: #932919;
   }
   /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a:hover {
+  #tof ul li a:hover {
     color: white;
     background: #671d12;
     border-color: #3c110a;
   }
   /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #toc ul li a:active {
+  #tof ul li a:active {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #tocx ul li a:active:active, #toc ul li a:active.active {
+  #tof ul li a:active:active, #tof ul li a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   }
 }
 /* line 151, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx ul li a {
+#tofx ul li a {
   border-top: none;
 }
 /* line 155, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx ul li a:hover {
+#tofx ul li a:hover {
   /* Cover the previous items border-bottom with our top */
   margin-top: -1px;
   border-top: 1px solid #3c110a;
 }
 /* line 180, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx ul li:last-child a {
+#tofx ul li:last-child a {
   border-bottom-color: transparent;
 }
 /* line 184, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tocx ul li:last-child a:hover {
+#tofx ul li:last-child a:hover {
   /* When we hover we want to show the last border */
   border-color: #3c110a;
 }

--- a/css/refactor-3.css
+++ b/css/refactor-3.css
@@ -1358,11 +1358,11 @@ body.centered-container {
 
 /* The table-of-contents itself */
 /* line 107, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_layout.scss */
-#tof {
+#toc {
   /*@import "../ui-config";*/
 }
 /* line 30, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tofx {
+#tocx {
   /* IMPORTANT height must be calculated by javascript. */
   width: 240px;
   margin: 0;
@@ -1373,7 +1373,7 @@ body.centered-container {
   -webkit-overflow-scrolling: touch;
 }
 /* line 46, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tofx h2 {
+#tocx h2 {
   display: block;
   font-family: "PT Serif", "Times New Roman", Times, serif;
   font-weight: 700;
@@ -1382,7 +1382,7 @@ body.centered-container {
   margin: 0;
 }
 /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx h2 a {
+#tocx h2 a {
   position: relative;
   display: block;
   font-size: 14.72px;
@@ -1393,38 +1393,38 @@ body.centered-container {
   border-left: none;
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited, #tofx h2 a:hover, #tofx h2 a:active {
+#tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited, #tocx h2 a:hover, #tocx h2 a:active {
   text-decoration: none;
 }
 /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited {
+#tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited {
   color: white;
   background: #3572a0;
 }
 /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx h2 a.active, #tofx h2 a:active {
+#tocx h2 a.active, #tocx h2 a:active {
   color: white;
   background: #932919;
 }
 /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx h2 a:hover {
+#tocx h2 a:hover {
   color: white;
   background: #671d12;
   border-color: #3c110a;
 }
 /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx h2 a:active {
+#tocx h2 a:active {
   /* Depressed state on click but not when marked active */
 }
 /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-#tofx h2 a:active:active, #tofx h2 a:active.active {
+#tocx h2 a:active:active, #tocx h2 a:active.active {
   -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
 }
 @media screen and (max-width: 800px) {
   /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tofx h2 a {
+  #tocx h2 a {
     position: relative;
     display: block;
     font-size: 14.72px;
@@ -1435,38 +1435,38 @@ body.centered-container {
     border-left: none;
   }
   /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited, #tofx h2 a:hover, #tofx h2 a:active {
+  #tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited, #tocx h2 a:hover, #tocx h2 a:active {
     text-decoration: none;
   }
   /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tofx h2 a, #tofx h2 a:link, #tofx h2 a:visited {
+  #tocx h2 a, #tocx h2 a:link, #tocx h2 a:visited {
     color: white;
     background: #3572a0;
   }
   /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tofx h2 a.active, #tofx h2 a:active {
+  #tocx h2 a.active, #tocx h2 a:active {
     color: white;
     background: #932919;
   }
   /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tofx h2 a:hover {
+  #tocx h2 a:hover {
     color: white;
     background: #671d12;
     border-color: #3c110a;
   }
   /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tofx h2 a:active {
+  #tocx h2 a:active {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #tofx h2 a:active:active, #tofx h2 a:active.active {
+  #tocx h2 a:active:active, #tocx h2 a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   }
 }
 /* line 101, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tofx .codenumber + .title {
+#tocx .codenumber + .title {
   display: -moz-inline-stack;
   display: inline-block;
   vertical-align: baseline;
@@ -1476,7 +1476,7 @@ body.centered-container {
   margin-left: 16.192px;
 }
 /* line 105, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tox .codenumber {
+#tocx .codenumber {
   position: absolute;
   right: 100%;
   margin-right: -21.456px;
@@ -1484,7 +1484,7 @@ body.centered-container {
 }
 @media screen and (max-width: 800px) {
   /* line 105, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-  #tof .codenumber {
+  #toc .codenumber {
     position: absolute;
     right: 100%;
     margin-right: -23.876px;
@@ -1492,19 +1492,19 @@ body.centered-container {
   }
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tofx ul {
+#tocx ul {
   margin: 0px;
   padding: 0px;
   list-style-type: none;
 }
 /* line 118, ../../../../../MathBook/mathbook-assets/scss/ui/partials/_toc.scss */
-#tofx ul li {
+#tocx ul li {
   display: block;
   margin: 0px;
   padding: 0px;
 }
 /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a {
+#tocx ul li a {
   position: relative;
   display: block;
   font-size: 14.72px;
@@ -1515,27 +1515,27 @@ body.centered-container {
   border-right: none;
 }
 /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a, #tofx ul li a:link, #tofx ul li a:visited, #tofx ul li a:hover, #tofx ul li a:active {
+#tocx ul li a, #tocx ul li a:link, #tocx ul li a:visited, #tocx ul li a:hover, #tocx ul li a:active {
   text-decoration: none;
 }
 /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a, #tofx ul li a:link, #tofx ul li a:visited {
+#tocx ul li a, #tocx ul li a:link, #tocx ul li a:visited {
   color: #671d12;
   background: #f0f0f0;
 }
 /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a.active, #tofx ul li a:active {
+#tocx ul li a.active, #tocx ul li a:active {
   color: white;
   background: #932919;
 }
 /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a:hover {
+#tocx ul li a:hover {
   color: white;
   background: #671d12;
   border-color: #3c110a;
 }
 /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a:active {
+#tocx ul li a:active {
   /* Depressed state on click but not when marked active */
 }
 /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
@@ -1546,7 +1546,7 @@ body.centered-container {
 }
 @media screen and (max-width: 800px) {
   /* line 98, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tof ul li a {
+  #toc ul li a {
     position: relative;
     display: block;
     font-size: 14.72px;
@@ -1557,52 +1557,52 @@ body.centered-container {
     border-left: none;
   }
   /* line 113, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tof ul li a, #tof ul li a:link, #tof ul li a:visited, #tof ul li a:hover, #tof ul li a:active {
+  #toc ul li a, #toc ul li a:link, #toc ul li a:visited, #toc ul li a:hover, #toc ul li a:active {
     text-decoration: none;
   }
   /* line 117, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tof ul li a, #tof ul li a:link, #tof ul li a:visited {
+  #toc ul li a, #toc ul li a:link, #toc ul li a:visited {
     color: #671d12;
     background: #f0f0f0;
   }
   /* line 128, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tof ul li a.active, #tof ul li a:active {
+  #toc ul li a.active, #toc ul li a:active {
     color: white;
     background: #932919;
   }
   /* line 133, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tof ul li a:hover {
+  #toc ul li a:hover {
     color: white;
     background: #671d12;
     border-color: #3c110a;
   }
   /* line 139, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-  #tof ul li a:active {
+  #toc ul li a:active {
     /* Depressed state on click but not when marked active */
   }
   /* line 215, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_buttons.scss */
-  #tof ul li a:active:active, #tof ul li a:active.active {
+  #toc ul li a:active:active, #toc ul li a:active.active {
     -webkit-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     -moz-box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
     box-shadow: rgba(0, 0, 0, 0.5) 0 2px 5px inset;
   }
 }
 /* line 151, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a {
+#tocx ul li a {
   border-top: none;
 }
 /* line 155, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li a:hover {
+#tocx ul li a:hover {
   /* Cover the previous items border-bottom with our top */
   margin-top: -1px;
   border-top: 1px solid #3c110a;
 }
 /* line 180, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li:last-child a {
+#tocx ul li:last-child a {
   border-bottom-color: transparent;
 }
 /* line 184, ../../../../../MathBook/mathbook-assets/scss/ui/mixins/_navtree.scss */
-#tofx ul li:last-child a:hover {
+#tocx ul li:last-child a:hover {
   /* When we hover we want to show the last border */
   border-color: #3c110a;
 }


### PR DESCRIPTION
This reorganizes the code in the table of contents (`#toc`) under a structure based on `ul`s and `li`s instead of `h2`s. The new code is contained in the file "new_a.css". 

Note that the old code was stored in "refactor-3.css", but it has not yet been entirely removed. This way, if a problem involving the new code arises, we can still look back to the old code to roughly gauge how to fix it. The old code has instead been deactivated by changing all instances of `#toc` to `#tocx`, which is meaningless. This should be removed in the future.

Additionally, the file "new_b.css" contains commented-out code that, when reactivated, changes the color scheme of the table of contents. This is not a change, strictly speaking, but it demonstrates how to change the colors of the table of contents if a user desires to do so. Additionally, all code pertaining to the current default color scheme is located at the bottom of "new_a.css".